### PR TITLE
Sass Dependency Should Be Optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,12 @@
     "grunt-contrib-uglify": "~0.2.4",
     "handlebars": "~1.0.12",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-sass": "~0.6.1",
-    "grunt-contrib-compass": "~0.6.0",
     "lodash": "~2.2.1",
     "connect-livereload": "~0.3.0",
     "grunt-contrib-jshint": "~0.7.1"
+  },
+  "optionalDependencies": {
+    "grunt-sass": "~0.6.1",
+    "grunt-contrib-compass": "~0.6.0"
   }
 }


### PR DESCRIPTION
Instead of requiring both sass modules (node-sass and ruby-sass), just make both dependencies optional and let the parent module decide.
