### PR TITLE
Removed optional dependencies completely

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,5 @@
     "lodash": "~2.2.1",
     "connect-livereload": "~0.3.0",
     "grunt-contrib-jshint": "~0.7.1"
-  },
-  "optionalDependencies": {
-    "grunt-sass": "~0.6.1",
-    "grunt-contrib-compass": "~0.6.0"
   }
 }

--- a/tasks/build-css.js
+++ b/tasks/build-css.js
@@ -1,6 +1,6 @@
 module.exports = function(grunt) {
     var tasks = [];
-    
+
     if (grunt.config.get('billy-builder.sass')) {
         tasks.push('sass');
     }

--- a/tasks/compass.js
+++ b/tasks/compass.js
@@ -7,13 +7,13 @@ module.exports = function(grunt) {
         return;
     }
 
-    grunt.loadTasks(path.join(__dirname, '../node_modules/grunt-contrib-compass/tasks'));
+    grunt.loadNpmTasks('grunt-contrib-compass');
 
     var dependencyDirs = ['bower_components'].concat(grunt.config.get('billy-builder.extraDependencyDirs'));
     var importPaths = dependencyDirs.map(function(dir) {
         return path.resolve(dir);
     });
-    
+
     grunt.config.set('compass', {
         dist: {
             options: {

--- a/tasks/sass.js
+++ b/tasks/sass.js
@@ -7,18 +7,18 @@ module.exports = function(grunt) {
         return;
     }
 
-    grunt.loadTasks(path.join(__dirname, '../node_modules/grunt-sass/tasks'));
+    grunt.loadNpmTasks('grunt-sass');
 
     var dependencyDirs = ['bower_components'].concat(grunt.config.get('billy-builder.extraDependencyDirs'));
     var includePaths = dependencyDirs.map(function(dir) {
         return path.resolve(dir);
     });
-    
+
     var versionPrefix = config.getVersionPrefix(grunt);
 
     var files = {};
     files['dist/'+versionPrefix+'css/bundle.css'] = grunt.config.get('billy-builder.sass.sassFile');
-    
+
     grunt.config.set('sass', {
         dist: {
             options: {


### PR DESCRIPTION
Since `optionalDependencies` (added in #8) actually do get installed, we remove them completely and fix the way we load the grunt tasks.

Host packages now have to add either `grunt-contrib-compass` or `grunt-sass` to their own `package.json` to use compass or sass.
